### PR TITLE
Added support for the YouTube Data API

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -419,7 +419,8 @@ export default class ThumbyPlugin extends Plugin {
 
 		try {
 			const reqParam: RequestUrlParam = {
-				url: reqUrl
+				url: reqUrl,
+				throw: false
 			};
 			const res = await requestUrl(reqParam);
 

--- a/main.ts
+++ b/main.ts
@@ -18,13 +18,15 @@ interface ThumbySettings {
 	saveImages: boolean;
 	imageLocation: string;
 	imageFolder: string;
+	youtubeApiKey: string;
 }
 
 const DEFAULT_SETTINGS: Partial<ThumbySettings> = {
 	storeInfo: false,
 	saveImages: false,
 	imageLocation: 'defaultAttachment',
-	imageFolder: ''
+	imageFolder: '',
+	youtubeApiKey: ''
 };
 
 export default class ThumbyPlugin extends Plugin {

--- a/main.ts
+++ b/main.ts
@@ -430,6 +430,22 @@ export default class ThumbyPlugin extends Plugin {
 				info.authorUrl = res.json.author_url;
 				info.vidFound = true;
 			}
+			else if(this.settings.youtubeApiKey) {
+				const videoId = await this.getVideoId(url);
+				const youtubeUrl = `https://youtube.googleapis.com/youtube/v3/videos?part=snippet&id=${videoId}&key=${this.settings.youtubeApiKey}`;
+				const youtubeReqParam: RequestUrlParam = {
+					url: youtubeUrl,
+					throw: false
+				};
+				const youtubeApiRes = await requestUrl(youtubeReqParam);
+				
+				if (youtubeApiRes.status === 200) {
+					const snippet = youtubeApiRes.json.items[0].snippet;
+					info.title = snippet.title;
+					info.author = snippet.channelTitle;
+					info.vidFound = true;
+				}
+			}
 
 			if (info.vidFound) {
 				if (isYoutube) {

--- a/main.ts
+++ b/main.ts
@@ -425,6 +425,13 @@ export default class ThumbyPlugin extends Plugin {
 			const res = await requestUrl(reqParam);
 
 			if (res.status === 200) {
+				info.title = res.json.title;
+				info.author = res.json.author_name;
+				info.authorUrl = res.json.author_url;
+				info.vidFound = true;
+			}
+
+			if (info.vidFound) {
 				if (isYoutube) {
 					// Returned thumbnail is usually letterboxed or wrong aspect ratio
 					const videoId = await this.getVideoId(url);
@@ -433,10 +440,6 @@ export default class ThumbyPlugin extends Plugin {
 				else {
 					info.thumbnail = res.json.thumbnail_url;
 				}
-				info.title = res.json.title;
-				info.author = res.json.author_name;
-				info.authorUrl = res.json.author_url;
-				info.vidFound = true;
 			}
 		} catch (error) {
 			console.error(error);

--- a/settings.ts
+++ b/settings.ts
@@ -91,6 +91,17 @@ export default class ThumbySettingTab extends PluginSettingTab {
 								})
 						);
 				}
+				new Setting(containerEl)
+					.setName('YouTube API Key')
+					.setDesc('The API Key for the YouTube Data API')
+					.addText((text) =>
+						text
+							.setValue(this.plugin.settings.youtubeApiKey)
+							.onChange(async (value) => {
+								this.plugin.settings.youtubeApiKey = value;
+								await this.plugin.saveSettings();
+							})
+					);
 			}
 		}
 	}


### PR DESCRIPTION
- Added a new setting 'YouTube API Key'
- Refactored the logic for retrieving the video metadata. If OEmbed fails and a YouTube API Key is configured try to obtain the metadata using the YouTube Data API

I tested it with a video for which OEmbed fails: https://www.youtube.com/watch?v=iG6fr81xHKA